### PR TITLE
Fix BEM class naming

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -43,29 +43,25 @@ Example of a two column, responsive, centered grid. All grid layout classes and 
 
 ## Settings
 
-**`$av-namespace`**  
+**`$av-namespace`**
 Global prefix for layout and cell class names. Default: `grid`.
 
-**`$av-gutter`**  
+**`$av-gutter`**
 Gutter width between cells. Default: `20px`.
 
-**`$av-width-class-namespace`**  
-Prefix for width class names. Default: `''`.
+**`$av-width-class-style`**
+Naming style of width classes. Default: `'fraction'`. Options: `fraction` (grid__cell--1/2, grid__cell--3/4 etc), `percentage` (grid__cell--25, grid__cell--50 etc), `fragment` (grid__cell--1-of-3, grid__cell--4-of-5 etc).
 
-**`$av-width-class-style`**  
-Naming style of width classes. Default: `'fraction'`. Options: `fraction` (1/2, 3/4 etc), `percentage` (25, 50 etc), `fragment` (1-of-3, 4-of-5 etc).  
-*N.B. If using percentage then `$av-width-class-namespace` above cannot be null. Avalanche escapes leading integers for fraction and fragment naming styles but this isn't possible with percentage style as Sass attempts to escape the whole number (e.g. 50 instead of just 5 or 30 instead of just 3) so fails*.
-
-**`$av-widths`**  
-Sass list of width denominator values (when expressed as a fraction). For example, 2 produces 1/2 width class, 3 produces 1/3 and 2/3 width classes etc. Default: `( 2, 3, 4 )`.  
+**`$av-widths`**
+Sass list of width denominator values (when expressed as a fraction). For example, 2 produces grid__cell--1/2 width class, 3 produces grid__cell--1/3 and grid__cell--2/3 width classes etc. Default: `( 2, 3, 4 )`.
 *N.B. This setting has a large impact on the size of your compiled CSS. Avoid bloat by inputting just the numbers you'll use.*
 
-**`$av-enable-responsive`**  
+**`$av-enable-responsive`**
 Enable/disable the inclusion of responsive width classes. With this enabled, class names (for denominators set above) will be created for each of your breakpoint aliases (set below). Default: `true`.
 
-**`$av-breakpoints`**  
-Sass map of responsive breakpoint aliases and associated media queries (in key-value pairs).  
-*N.B. This setting has a large impact on the size of your compiled CSS. Avoid bloat by inputting just the breakpoints you'll use.*  
+**`$av-breakpoints`**
+Sass map of responsive breakpoint aliases and associated media queries (in key-value pairs).
+*N.B. This setting has a large impact on the size of your compiled CSS. Avoid bloat by inputting just the breakpoints you'll use.*
 Default:
 ```
 (
@@ -88,41 +84,41 @@ Apply as modifier classes to your base `grid` element. For example; `<div class=
 
 All optionable grid layouts listed below are switched off by default. Set to `true` to enable.
 
-**`$av-enable-grid-center`**  
+**`$av-enable-grid-center`**
 All cells are horizontally centered within the container.
 
-**`$av-enable-grid-cell-center`**  
-Center an individual grid cell within the container.  
+**`$av-enable-grid-cell-center`**
+Center an individual grid cell within the container.
 *N.B. Class should be applied to an individual cell, not the grid container. For example; `<div class="grid__cell grid__cell--center">`.*
 
-**`$av-enable-grid-right`**  
+**`$av-enable-grid-right`**
 All cells are horizontally aligned to the right within the container.
 
-**`$av-enable-grid-middle`**  
+**`$av-enable-grid-middle`**
 All cells are vertically centered within in the container.
 
-**`$av-enable-grid-bottom`**  
+**`$av-enable-grid-bottom`**
 All cells are vertically aligned to the bottom of the container.
 
-**`$av-enable-grid-flush`**  
+**`$av-enable-grid-flush`**
 Gutters removed between cells.
 
-**`$av-enable-grid-tiny`**  
+**`$av-enable-grid-tiny`**
 Gutters between cells set to a quarter of the global gutter value. Default: `5px`.
 
-**`$av-enable-grid-small`**  
+**`$av-enable-grid-small`**
 Gutters between cells set to half of the global gutter value. Default: `10px`.
 
-**`$av-enable-grid-large`**  
+**`$av-enable-grid-large`**
 Gutters between cells set to double the global gutter value. Default: `40px`.
 
-**`$av-enable-grid-huge`**  
+**`$av-enable-grid-huge`**
 Gutters between cells set to quadruple the global gutter value. Default: `80px`.
 
-**`$av-enable-grid-auto`**  
+**`$av-enable-grid-auto`**
 All cells take up an unspecified width set by their content.
 
-**`$av-enable-grid-rev`**  
+**`$av-enable-grid-rev`**
 Grid cells are displayed in the opposite of their source order.
 
 ## Media query

--- a/_avalanche.scss
+++ b/_avalanche.scss
@@ -7,8 +7,7 @@
 $av-namespace:  'grid' !default;  // Prefix namespace for grid layout and cells
 $av-gutter:     20px !default;    // Gutter between grid cells
 
-$av-width-class-namespace:  '' !default;          // Prefix namespace for width classes. For example; 'col-'
-$av-width-class-style:      'fraction' !default;  // Width class naming style. Can be 'fraction', 'percentage' or 'fragment'
+$av-width-class-style:  'fraction' !default;  // Width class naming style. Can be 'fraction', 'percentage' or 'fragment'
 $av-widths: (
   2,
   3,
@@ -51,23 +50,6 @@ $av-enable-grid-rev:          false !default;
     LOGIC aka THE MAGIC
 \*------------------------------------*/
 
-@function escapeNumerator($numerator, $namespace: ''){
-  @if($namespace == ''){
-    $numerator-as-string: inspect($numerator);
-    $escaped-numerator: '';
-
-    // Loop through all digits in the numerator and escape individually
-    @for $i from 1 through str-length($numerator-as-string){
-      $digit: str-slice($numerator-as-string, $i, $i);
-      $escaped-numerator: $escaped-numerator+\3+$digit;
-    }
-
-    @return $escaped-numerator;
-  } @else {
-    @return $numerator;
-  }
-}
-
 @function avCreateClassName($style, $numerator, $denominator, $breakpoint-alias){
 
   $class-name: null;
@@ -75,13 +57,10 @@ $av-enable-grid-rev:          false !default;
   @if $style == 'fraction' or $style == 'fragment'{
     // Set delimiter as slash or text
     $delimiter: if($style == 'fraction', \/, -of-);
-    $class-name: #{$av-width-class-namespace}#{escapeNumerator($numerator, $av-width-class-namespace)}#{$delimiter}#{$denominator}#{$breakpoint-alias};
+    $class-name: "grid__cell--#{$numerator}#{$delimiter}#{$denominator}#{$breakpoint-alias}";
   } @else{
-    @if $av-width-class-namespace == ''{
-      @error "Percentage value class names require a namespace to be set (see $av-width-class-namespace). Selective escaping (e.g. the 5 of 50) cannot be done.";
-    }
     $class-width: floor(($numerator / $denominator) * 100);
-    $class-name: #{$av-width-class-namespace}#{$class-width}#{$breakpoint-alias};
+    $class-name: "grid__cell--#{$class-width}#{$breakpoint-alias}";
   }
 
   @return $class-name;
@@ -322,7 +301,7 @@ $av-enable-grid-rev:          false !default;
 
     // Create each media query
     @media #{$query}{
-      @include av-create-widths($av-widths, --#{$alias});
+      @include av-create-widths($av-widths, -for-#{$alias});
     }
   }
 }


### PR DESCRIPTION
Class names like `1/2`, `50` and `1-of-2` pollute the global namespace.
These classes describe cell widths, so make them be modifiers of the
`grid__cell` element:
- grid__cell--1/2
- grid__cell--50
- grid__cell--1-of-2

Modifiers should _modify_ a block or an element. They should not be used
by themselves. Consider the markup:

```
<div class="grid">
  <div class="1/2 1/4--wide grid__cell">Cell</div>
  <div class="1/2 1/4--wide grid__cell">Cell</div>
  <div class="1/2 1/4--wide grid__cell">Cell</div>
  <div class="1/2 1/4--wide grid__cell">Cell</div>
</div>
```

The `wide` modifier is being used on a `1/4` block, but the block itself
is not referenced. Instead it's understood that the `grid__cell` is
`1/2` until `wide` when it becomes `1/4`. The classes used in the above
example are disassociative.

Improve this concept:

```
<div class="grid">
  <div class="grid__cell grid__cell--1/2 grid__cell--1/4-for-wide">Cell</div>
  <div class="grid__cell grid__cell--1/2 grid__cell--1/4-for-wide">Cell</div>
  <div class="grid__cell grid__cell--1/2 grid__cell--1/4-for-wide">Cell</div>
  <div class="grid__cell grid__cell--1/2 grid__cell--1/4-for-wide">Cell</div>
</div>
```

This example more accurately expresses the width + responsive logic,
using BEM-like naming.
