### PR TITLE
Removing the deprecation warning.

### DIFF
--- a/_avalanche.scss
+++ b/_avalanche.scss
@@ -1,5 +1,5 @@
 /*! Avalanche | MIT License | @colourgarden */
-
+@use 'sass:math';
 /**
  * SETTINGS
  */
@@ -113,7 +113,7 @@ $av-enable-grid-rev:          false !default;
 
         // Create class name and set width value
         $class-name: av-create-width-class-name($av-width-class-style, $numerator, $denominator, $breakpoint-alias);
-        $width-value: percentage($numerator / $denominator);
+        $width-value: percentage(math.div($numerator, $denominator));
 
         // Is this width already in our utility map?
         $duplicate: map-get($pseudo-class-map, $width-value);


### PR DESCRIPTION
SASS currently treats / as a division operation in some contexts and a separator in others. This makes it difficult for Sass users to tell what any given / will mean, and makes it hard to work with new CSS features that use / as a separator. To ease the transition, I added the math.div() function. The / operator still does division for now, but it also prints a deprecation warning when it does so. Users should switch all division to use math.div() instead.